### PR TITLE
Make allowed_sync_hosts option in container-server.conf customizable.

### DIFF
--- a/manifests/storage/container.pp
+++ b/manifests/storage/container.pp
@@ -1,5 +1,6 @@
 class swift::storage::container(
-  $package_ensure = 'present'
+  $package_ensure = 'present',
+  $allowed_sync_hosts = ['127.0.0.1'],
 ) {
   swift::storage::generic { 'container':
     package_ensure => $package_ensure

--- a/templates/container-server.conf.erb
+++ b/templates/container-server.conf.erb
@@ -6,6 +6,7 @@ mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_LOCAL2
 workers = <%= workers %>
+allowed_sync_hosts = <%= scope.lookupvar("swift::storage::container::allowed_sync_hosts").to_a.join(',') %>
 
 [pipeline:main]
 pipeline = <%= pipeline.to_a.join(' ') %>


### PR DESCRIPTION
Patch writes a default value for allowed_sync_hosts into container-server.conf (http://docs.openstack.org/folsom/openstack-object-storage/admin/content/container-server-configuration.html) but allows to customize it like 

``` ruby
  class { 'swift::storage::container': allowed_sync_hosts => ['127.0.0.1', 'swift01', 'swift02'] }
  class { 'swift::storage::all':
    storage_local_net_ip => $ipaddress_eth1,
  }
```
